### PR TITLE
Add /Chat/submit endpoint

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "build": "dotnet run build --project EnterpriseAI.API"
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,0 @@
-{
-  "tasks": {
-    "build": "dotnet run build --project EnterpriseAI.API"
-  }
-}

--- a/EnterpriseAI.Core/Models/ChatMessage.cs
+++ b/EnterpriseAI.Core/Models/ChatMessage.cs
@@ -1,5 +1,6 @@
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
+using System.Text.Json.Serialization;
 
 namespace EnterpriseAI.Core.Models;
 
@@ -14,14 +15,15 @@ public class ChatMessage
 {
     public MessageRole Role { get; set; }
     public string Content { get; set; }
-    public DateTimeOffset Timestamp { get; set; }
+    public DateTimeOffset? Timestamp { get; set; }
 
-    public ChatMessage(MessageRole role, string content)
+    public ChatMessage(MessageRole role, string content, DateTimeOffset? timestamp = null)
     {
         Role = role;
         Content = content;
-        Timestamp = DateTimeOffset.UtcNow;
+        Timestamp = timestamp ?? DateTimeOffset.UtcNow;
     }
+
     public static ChatMessageContent ToKernelMessage(ChatMessage message)
     {
         var role = message.Role switch
@@ -33,4 +35,17 @@ public class ChatMessage
         };
         return new ChatMessageContent(role, message.Content);
     }
+
+    public static ChatMessage FromMessage(Message message)
+    {
+        var role = Enum.Parse<MessageRole>(message.Role, true);
+        return new ChatMessage(role, message.Content);
+    }
 }
+
+public record Message(
+    [property: JsonPropertyName("role")]
+    string Role,
+    [property: JsonPropertyName("content")]
+    string Content
+);


### PR DESCRIPTION
Add support for `/Chat/submit` endpoint to accept a `messages` array with `role` and `content`.

* **ChatMessage.cs**
  - Add `using System.Text.Json.Serialization;` to fix build error.
  - Make `Timestamp` property optional in `ChatMessage` class.
  - Add a constructor to accept `role`, `content`, and optional `timestamp` parameters.
  - Add a static method `FromMessage` to convert a `Message` object to a `ChatMessage` object.
  - Define a `Message` record with `role` and `content` properties.
